### PR TITLE
Build containers from root directory in release workflow (#2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,9 +200,8 @@ jobs:
           VERSION="${{ matrix.item.version }}"
 
           if [[ -f "$TYPE/$NAME/Dockerfile" ]]; then
-            cd "$TYPE/$NAME"
             IMAGE="ghcr.io/${{ github.repository }}/$NAME"
-            docker build -t $IMAGE:$VERSION -t $IMAGE:latest .
+            docker build -f "$TYPE/$NAME/Dockerfile" -t $IMAGE:$VERSION -t $IMAGE:latest .
             docker push $IMAGE:$VERSION
             docker push $IMAGE:latest
             echo "Published container $IMAGE:$VERSION"


### PR DESCRIPTION
- Modified container build step to use -f flag with Dockerfile path
- Removed cd command that changed to service/extension directory
- Build context now remains at root directory as requested
- Maintains existing Dockerfile structure and functionality

Fixes #2 