### PR TITLE
Fix issues with proto loading and common.Prompt usage in the LLM service

### DIFF
--- a/packages/libservice/index.js
+++ b/packages/libservice/index.js
@@ -153,7 +153,7 @@ export class Client extends Actor {
    */
   async #setupClient() {
     try {
-      const proto = await this.loadProto(this.config.name);
+      const proto = await this.loadProto(`${this.config.name}.proto`);
       const ServiceClass = proto[capitalizeFirstLetter(this.config.name)];
 
       if (!ServiceClass) {

--- a/services/llm/index.js
+++ b/services/llm/index.js
@@ -30,11 +30,7 @@ class LlmService extends LlmBase {
   async CreateCompletions(req) {
     const llm = this.#llmFactory(req.github_token, this.config.model);
 
-    // Use the properly typed prompt and its messages directly
-    const messages =
-      req.prompt instanceof common.Prompt
-        ? req.prompt.messages
-        : req.prompt.messages;
+    const messages = req.prompt.toMessages();
 
     // Log prompt details
     this.debug("Creating completion for prompt", {


### PR DESCRIPTION
This pull request includes updates to improve consistency and correctness in service initialization and prompt handling for the LLM service. The main changes focus on ensuring the correct protocol file is loaded and simplifying the way prompt messages are retrieved.

Service initialization improvements:
* Updated the client setup in `Client` to load the protocol file using the full filename (e.g., `service_name.proto`) instead of just the service name, ensuring compatibility with expected file naming conventions.

Prompt handling simplification:
* Refactored the `CreateCompletions` method in `LlmService` to use `req.prompt.toMessages()` for retrieving prompt messages, streamlining the logic and reducing type checks.