### PR TITLE
Replace gray-matter with small custom function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jsdoc": "^52.0.4",
         "globals": "^16.3.0",
-        "gray-matter": "^4.0.3",
         "html-minifier-terser": "^7.2.0",
         "marked": "^14.1.0",
         "marked-gfm-heading-id": "^4.1.0",
@@ -5188,6 +5187,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5267,18 +5267,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
@@ -5781,43 +5769,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6413,15 +6364,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6534,9 +6476,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6862,15 +6804,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/klaw": {
@@ -12627,19 +12560,6 @@
         "node": ">=v12.22.7"
       }
     },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -12901,9 +12821,9 @@
       }
     },
     "node_modules/spellchecker-cli/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12958,6 +12878,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/string_decoder": {
@@ -13024,15 +12945,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -14105,8 +14017,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.0.0",
-        "gray-matter": "^4.0.3",
         "hono": "^4.0.0",
+        "js-yaml": "^4.1.0",
         "marked": "^14.1.0",
         "marked-gfm-heading-id": "^4.1.0",
         "marked-highlight": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jsdoc": "^52.0.4",
     "globals": "^16.3.0",
-    "gray-matter": "^4.0.3",
     "html-minifier-terser": "^7.2.0",
     "marked": "^14.1.0",
     "marked-gfm-heading-id": "^4.1.0",

--- a/packages/libdoc/bin/build.js
+++ b/packages/libdoc/bin/build.js
@@ -3,11 +3,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { marked } from "marked";
-import matter from "gray-matter";
 import mustache from "mustache";
 import prettier from "prettier";
 
 import { DocsBuilder } from "@copilot-ld/libdoc";
+import { parseFrontMatter } from "../frontmatter.js";
 
 /**
  * Main function to handle CLI execution
@@ -28,7 +28,7 @@ async function main() {
     fs,
     path,
     marked,
-    matter,
+    parseFrontMatter,
     mustache.render,
     prettier,
   );

--- a/packages/libdoc/bin/serve.js
+++ b/packages/libdoc/bin/serve.js
@@ -6,11 +6,11 @@ import { parseArgs } from "node:util";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { marked } from "marked";
-import matter from "gray-matter";
 import mustache from "mustache";
 import prettier from "prettier";
 
 import { DocsBuilder, DocsServer } from "@copilot-ld/libdoc";
+import { parseFrontMatter } from "../frontmatter.js";
 
 /**
  * Main function to handle CLI execution
@@ -48,7 +48,7 @@ async function main() {
     fs,
     path,
     marked,
-    matter,
+    parseFrontMatter,
     mustache.render,
     prettier,
   );

--- a/packages/libdoc/builder.js
+++ b/packages/libdoc/builder.js
@@ -18,7 +18,7 @@ export class DocsBuilder {
    * @param {object} fs - File system module
    * @param {object} path - Path module
    * @param {Function} markedParser - Marked parser function
-   * @param {Function} matterParser - Gray-matter parser function
+   * @param {Function} matterParser - Front matter parser function
    * @param {Function} mustacheRender - Mustache render function
    * @param {object} prettier - Prettier module for HTML formatting
    */

--- a/packages/libdoc/frontmatter.js
+++ b/packages/libdoc/frontmatter.js
@@ -1,0 +1,30 @@
+/* eslint-env node */
+import yaml from "js-yaml";
+
+/**
+ * Parse simple front matter from markdown content
+ * @param {string} content - Markdown content with optional front matter
+ * @returns {{data: object, content: string}} Parsed front matter and remaining content
+ */
+export function parseFrontMatter(content) {
+  const data = {};
+
+  // Check if content starts with ---
+  if (!content.trimStart().startsWith("---")) {
+    return { data, content };
+  }
+
+  // Find the closing ---
+  const match = content.match(/^\s*---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    return { data, content };
+  }
+
+  const [, frontMatter, remainingContent] = match;
+  const parsedData = yaml.load(frontMatter);
+
+  return {
+    data: parsedData || {},
+    content: remainingContent,
+  };
+}

--- a/packages/libdoc/index.js
+++ b/packages/libdoc/index.js
@@ -2,3 +2,4 @@
 
 export { DocsBuilder } from "./builder.js";
 export { DocsServer } from "./server.js";
+export { parseFrontMatter } from "./frontmatter.js";

--- a/packages/libdoc/package.json
+++ b/packages/libdoc/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.0.0",
-    "gray-matter": "^4.0.3",
     "hono": "^4.0.0",
+    "js-yaml": "^4.1.0",
     "marked": "^14.1.0",
     "marked-gfm-heading-id": "^4.1.0",
     "marked-highlight": "^2.1.0",


### PR DESCRIPTION
`gray-matter` is pulling in an old version of js-yaml with a recent CVE. This PR fixes this issues.

This is also really sad: https://nolanlawson.com/2025/11/16/the-fate-of-small-open-source/