### PR TITLE
fix 355

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
     steps:
       - name: Generate release token
         id: release-manager
@@ -41,6 +42,8 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Bump versions and tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git status
           git pull --rebase origin main


### PR DESCRIPTION
- **Utility workflow to manually publish individual packages**
- **fix(ci): add packages:read permission and NODE_AUTH_TOKEN to bump workflow**
